### PR TITLE
Add overload signature for Matrix multiplication.

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -220,6 +220,8 @@ export class Mat {
    * @returns a vector in case of matrix vector multiplication, else a matrix
    * @throws dimension Mismatch if dimensions doesn't match
    */
+  mul(param: Mat | number): Mat;
+  mul(param: Vec): Vec;
   mul(param: Mat | number | Vec): Mat | Vec {
     if (typeof param === 'number') {
       const multipliedValues: number[] = this.values.map(


### PR DESCRIPTION
Currently when multiplying a matrix and a vector using `Mat.mul` the compiler cannot infer whether the return type is a `Mat` or `Vec` based on input. Because the result ends up typed as `Mul | Vec` users need to cast to the type they know it should be when using the result, i.e. `mat.mul(vec) as Vec`. This pull request adds overload signatures for `Mat.mul` so that the compiler knows whether the result is a `Mat` or `Vec` based on the input type.